### PR TITLE
Implement reflection mapping in CustomDTOProvider

### DIFF
--- a/pkg/dto/dto.go
+++ b/pkg/dto/dto.go
@@ -166,8 +166,16 @@ func (p *CustomDTOProvider) TransformToModel(dto interface{}) (interface{}, erro
 	}
 	model := reflect.New(modelType).Interface()
 
-	// Map fields from DTO to model
-	// Here you can use a library like mapstructure or manually map fields
+	// Map fields from DTO to model using reflection
+	dtoVal := reflect.ValueOf(dto).Elem()
+	modelVal := reflect.ValueOf(model).Elem()
+
+	for i := 0; i < dtoVal.NumField(); i++ {
+		fieldName := dtoVal.Type().Field(i).Name
+		if modelField := modelVal.FieldByName(fieldName); modelField.IsValid() && modelField.CanSet() {
+			modelField.Set(dtoVal.Field(i))
+		}
+	}
 
 	return model, nil
 }
@@ -180,8 +188,16 @@ func (p *CustomDTOProvider) TransformFromModel(model interface{}) (interface{}, 
 	}
 	dto := reflect.New(dtoType).Interface()
 
-	// Map fields from model to DTO
-	// Here you can use a library like mapstructure or manually map fields
+	// Map fields from model to DTO using reflection
+	modelVal := reflect.ValueOf(model).Elem()
+	dtoVal := reflect.ValueOf(dto).Elem()
+
+	for i := 0; i < dtoVal.NumField(); i++ {
+		fieldName := dtoVal.Type().Field(i).Name
+		if modelField := modelVal.FieldByName(fieldName); modelField.IsValid() {
+			dtoVal.Field(i).Set(modelField)
+		}
+	}
 
 	return dto, nil
 }

--- a/pkg/dto/dto_test.go
+++ b/pkg/dto/dto_test.go
@@ -127,3 +127,31 @@ func TestDefaultDTOProviderWithoutCustomDTOs(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, modelData, dto)
 }
+
+func TestCustomDTOProviderRoundTrip(t *testing.T) {
+	provider := &CustomDTOProvider{
+		Model:       &TestModel{},
+		CreateDTO:   &TestCreateDTO{},
+		UpdateDTO:   &TestUpdateDTO{},
+		ResponseDTO: &TestResponseDTO{},
+	}
+
+	createData := &TestCreateDTO{
+		Name:  "Alice",
+		Email: "alice@example.com",
+		Age:   20,
+	}
+
+	model, err := provider.TransformToModel(createData)
+	assert.NoError(t, err)
+	assert.IsType(t, &TestModel{}, model)
+
+	dto, err := provider.TransformFromModel(model)
+	assert.NoError(t, err)
+	assert.IsType(t, &TestResponseDTO{}, dto)
+
+	resp := dto.(*TestResponseDTO)
+	assert.Equal(t, "Alice", resp.Name)
+	assert.Equal(t, "alice@example.com", resp.Email)
+	assert.Equal(t, 20, resp.Age)
+}


### PR DESCRIPTION
## Summary
- implement field mapping for `CustomDTOProvider`
- add unit tests verifying round‑trip conversions for custom DTO provider

## Testing
- `go test ./...` *(fails: Forbidden downloading modules)*

------
https://chatgpt.com/codex/tasks/task_e_68442cafc3c88327b264bcfb1ba08560