### PR TITLE
Add tests for query parsing helpers

### DIFF
--- a/pkg/query/parsing_test.go
+++ b/pkg/query/parsing_test.go
@@ -45,6 +45,7 @@ func TestParseQueryParam(t *testing.T) {
 		{"true", "bool", true, false},
 		{"maybe", "bool", false, true},
 		{"some", "string", "some", false},
+		{"sample", "unknown", "sample", false},
 	}
 
 	for _, tt := range tests {

--- a/pkg/query/parsing_test.go
+++ b/pkg/query/parsing_test.go
@@ -1,0 +1,61 @@
+package query
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseId(t *testing.T) {
+	tests := []struct {
+		input       string
+		expected    uint
+		expectError bool
+	}{
+		{"123", 123, false},
+		{"0", 0, false},
+		{"abc", 0, true},
+		{"12a", 0, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			id, err := ParseId(tt.input)
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expected, id)
+			}
+		})
+	}
+}
+
+func TestParseQueryParam(t *testing.T) {
+	tests := []struct {
+		value       string
+		typ         string
+		expected    interface{}
+		expectError bool
+	}{
+		{"42", "int", 42, false},
+		{"notint", "int", 0, true},
+		{"3.14", "float", 3.14, false},
+		{"nofloat", "float", 0.0, true},
+		{"true", "bool", true, false},
+		{"maybe", "bool", false, true},
+		{"some", "string", "some", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.typ+"_"+tt.value, func(t *testing.T) {
+			res, err := ParseQueryParam(tt.value, tt.typ)
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expected, res)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- add table-driven tests for `ParseId` and `ParseQueryParam`

## Testing
- `go test ./...` *(fails: unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68442e897c848327b04c111df28c69ce