### PR TITLE
Add DefaultCacheConfig test

### DIFF
--- a/pkg/middleware/cache_test.go
+++ b/pkg/middleware/cache_test.go
@@ -1,15 +1,26 @@
 package middleware
 
 import (
-	"fmt"
-	"net/http"
-	"net/http/httptest"
-	"testing"
+        "fmt"
+        "net/http"
+        "net/http/httptest"
+        "testing"
 
-	"github.com/gin-gonic/gin"
-	"github.com/stretchr/testify/assert"
-	"github.com/suranig/refine-gin/pkg/utils"
+        "github.com/gin-gonic/gin"
+        "github.com/stretchr/testify/assert"
+        "github.com/suranig/refine-gin/pkg/utils"
 )
+
+func TestDefaultCacheConfig(t *testing.T) {
+        expected := CacheConfig{
+                MaxAge:       60,
+                DisableCache: false,
+                Methods:      []string{"GET", "HEAD"},
+                VaryHeaders:  []string{"Accept", "Accept-Encoding", "Authorization"},
+        }
+
+        assert.Equal(t, expected, DefaultCacheConfig())
+}
 
 func TestCache(t *testing.T) {
 	// Set Gin to test mode


### PR DESCRIPTION
## Summary
- add unit test verifying DefaultCacheConfig settings

## Testing
- `go test ./...` *(fails: could not download modules)*

------
https://chatgpt.com/codex/tasks/task_e_68443996749c8327a1bd413b4570dfe1