### PR TITLE
Add tests for CustomDTOProvider getters

### DIFF
--- a/pkg/dto/custom_dto_provider_test.go
+++ b/pkg/dto/custom_dto_provider_test.go
@@ -1,0 +1,38 @@
+package dto
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCustomDTOProviderGetters(t *testing.T) {
+	provider := &CustomDTOProvider{
+		Model:       &TestModel{},
+		CreateDTO:   &TestCreateDTO{},
+		UpdateDTO:   &TestUpdateDTO{},
+		ResponseDTO: &TestResponseDTO{},
+	}
+
+	createDTO := provider.GetCreateDTO()
+	assert.IsType(t, &TestCreateDTO{}, createDTO)
+	assert.NotSame(t, provider.CreateDTO, createDTO)
+
+	updateDTO := provider.GetUpdateDTO()
+	assert.IsType(t, &TestUpdateDTO{}, updateDTO)
+	assert.NotSame(t, provider.UpdateDTO, updateDTO)
+
+	responseDTO := provider.GetResponseDTO()
+	assert.IsType(t, &TestResponseDTO{}, responseDTO)
+	assert.NotSame(t, provider.ResponseDTO, responseDTO)
+}
+
+func TestCustomDTOProviderFallbackToModel(t *testing.T) {
+	provider := &CustomDTOProvider{
+		Model: &TestModel{},
+	}
+
+	assert.Same(t, provider.Model, provider.GetCreateDTO())
+	assert.Same(t, provider.Model, provider.GetUpdateDTO())
+	assert.Same(t, provider.Model, provider.GetResponseDTO())
+}


### PR DESCRIPTION
## Summary
- add tests ensuring CustomDTOProvider getters create new instances
- verify getters fall back to the model when custom structs are not provided

## Testing
- `make lint` *(fails: Forbidden downloading mimetype)*
- `make test` *(fails: Forbidden downloading mimetype)*

------
https://chatgpt.com/codex/tasks/task_e_6844398c25848327b7ff6f386a5e39fd