### PR TITLE
Add tests for validation tags and form layout

### DIFF
--- a/pkg/resource/parse_validation_tag_test.go
+++ b/pkg/resource/parse_validation_tag_test.go
@@ -1,0 +1,40 @@
+package resource
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseValidationTag(t *testing.T) {
+	tests := []struct {
+		tag  string
+		want *JsonValidation
+	}{
+		{
+			tag:  "required",
+			want: &JsonValidation{Required: true},
+		},
+		{
+			tag:  "min=1,max=10",
+			want: &JsonValidation{Min: 1, Max: 10},
+		},
+		{
+			tag:  "minlength=5,maxlength=20",
+			want: &JsonValidation{MinLength: 5, MaxLength: 20},
+		},
+		{
+			tag:  "required,min=0,max=100,minlength=2,maxlength=10",
+			want: &JsonValidation{Required: true, Min: 0, Max: 100, MinLength: 2, MaxLength: 10},
+		},
+		{
+			tag:  "min=foo,max=bar",
+			want: &JsonValidation{},
+		},
+	}
+
+	for _, tt := range tests {
+		got := parseValidationTag(tt.tag)
+		assert.Equal(t, tt.want, got, "tag: %s", tt.tag)
+	}
+}

--- a/pkg/resource/resource_test.go
+++ b/pkg/resource/resource_test.go
@@ -549,3 +549,32 @@ func TestGetEditableFields(t *testing.T) {
 	assert.NotContains(t, explicitEditable, "Email")
 	assert.NotContains(t, explicitEditable, "Role")
 }
+
+func TestGetFormLayoutDefaultGeneration(t *testing.T) {
+	fields := []Field{
+		{Name: "ID"},
+		{Name: "First"},
+		{Name: "Second"},
+		{Name: "Hidden", Hidden: true},
+		{Name: "Third"},
+	}
+
+	res := &DefaultResource{Name: "users", Model: TestUser{}, Fields: fields}
+
+	// No layout specified should return nil
+	assert.Nil(t, res.GetFormLayout())
+
+	layout := GenerateDefaultFormLayout(res.GetFields())
+	if layout == nil {
+		t.Fatal("GenerateDefaultFormLayout returned nil")
+	}
+
+	got := make([]string, 0, len(layout.FieldLayouts))
+	for _, fl := range layout.FieldLayouts {
+		got = append(got, fl.Field)
+	}
+
+	// ID and hidden fields should be skipped and order preserved
+	expected := []string{"First", "Second", "Third"}
+	assert.Equal(t, expected, got)
+}


### PR DESCRIPTION
## Summary
- test `parseValidationTag` against multiple tag combinations
- verify default form layout order when no layout configured

## Testing
- `go test ./...` *(fails: fetching module github.com/gabriel-vasile/mimetype)*

------
https://chatgpt.com/codex/tasks/task_e_68444079f8208327af5dce033782c4b2