### PR TITLE
Add coverage for invalid ID formats and relation validation

### DIFF
--- a/pkg/handler/many_test.go
+++ b/pkg/handler/many_test.go
@@ -710,7 +710,7 @@ func TestCreateManyHandler_RelationValidationFailure(t *testing.T) {
 
 	items := []RelModel{{ID: "1", Category: nil}}
 	mockDTOProvider.On("TransformToModel", mock.Anything).Return(items, nil)
-	mockRepo.On("Query", mock.Anything).Return(nil)
+	mockRepo.On("Query", mock.Anything).Return(&gorm.DB{})
 
 	r.POST("/tests/batch", GenerateCreateManyHandler(res, mockRepo, mockDTOProvider))
 


### PR DESCRIPTION
## Summary
- test invalid ID formats for bulk update/delete
- test relation validation failure on bulk create

## Testing
- `go test ./...` *(fails: Forbidden downloading modules)*

------
https://chatgpt.com/codex/tasks/task_e_684449ffb1c88327a3e683db0e7238e4