### PR TITLE
Add tests for custom and async validators

### DIFF
--- a/pkg/resource/field_test.go
+++ b/pkg/resource/field_test.go
@@ -282,3 +282,15 @@ func TestConditionalValidatorValidate(t *testing.T) {
 	err = statusValidator.Validate(nil)
 	assert.NoError(t, err)
 }
+
+func TestCustomValidatorValidate(t *testing.T) {
+	validator := CustomValidator{Expression: "1 == 1", Message: "should pass"}
+	err := validator.Validate("anything")
+	assert.NoError(t, err)
+}
+
+func TestAsyncValidatorValidate(t *testing.T) {
+	validator := AsyncValidator{URL: "https://example.com", Message: "async"}
+	err := validator.Validate("sample")
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
## Summary
- expand `pkg/resource/field_test.go` with tests for `CustomValidator` and `AsyncValidator`

## Testing
- `go test ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68447006e90883279a8b00a68f5031ba