### PR TITLE
Add malformed JSON test

### DIFF
--- a/pkg/middleware/naming_test.go
+++ b/pkg/middleware/naming_test.go
@@ -3,6 +3,7 @@ package middleware
 import (
 	"bytes"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -226,6 +227,29 @@ func TestNamingConventionMiddleware_NonJSONRequest(t *testing.T) {
 	// Check that the response is as expected (middleware should not affect it)
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, "Hello, John", w.Body.String())
+}
+
+func TestNamingConventionMiddleware_MalformedJSON(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	r := gin.New()
+	r.Use(NamingConventionMiddleware(naming.SnakeCase))
+
+	// Echo back the raw request body so we can verify it is unchanged
+	r.POST("/malformed", func(c *gin.Context) {
+		body, err := io.ReadAll(c.Request.Body)
+		assert.NoError(t, err)
+		c.Data(http.StatusOK, "application/json", body)
+	})
+
+	malformed := "{invalid json"
+	req := httptest.NewRequest(http.MethodPost, "/malformed", bytes.NewBufferString(malformed))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, malformed, w.Body.String())
 }
 
 // Helper function to assert that two maps are equivalent, accounting for JSON type conversions


### PR DESCRIPTION
## Summary
- extend naming middleware tests for malformed JSON

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6844719e79148327aef1d0eb36ae382f