### PR TITLE
Add validation error cases

### DIFF
--- a/pkg/resource/utils_test.go
+++ b/pkg/resource/utils_test.go
@@ -704,6 +704,68 @@ func TestValidateNestedJson(t *testing.T) {
 			},
 		},
 		{
+			name: "Invalid JSON string",
+			data: `{"name": "Test Name", "age": 30`,
+			config: &JsonConfig{
+				Properties: []JsonProperty{
+					{
+						Path:       "name",
+						Type:       "string",
+						Validation: &JsonValidation{Required: true},
+					},
+				},
+			},
+			expectedValid: false,
+			expectedErrors: []string{
+				"Invalid JSON string",
+			},
+		},
+		{
+			name: "Nested object missing required field",
+			data: map[string]interface{}{
+				"name": "Test Name",
+				"address": map[string]interface{}{
+					"street": "123 Main St",
+					"zip":    "12345",
+				},
+			},
+			config: &JsonConfig{
+				Properties: []JsonProperty{
+					{
+						Path:       "name",
+						Type:       "string",
+						Validation: &JsonValidation{Required: true},
+					},
+					{
+						Path: "address",
+						Type: "object",
+						Properties: []JsonProperty{
+							{
+								Path:       "street",
+								Type:       "string",
+								Validation: &JsonValidation{Required: true},
+							},
+							{
+								Path:       "city",
+								Type:       "string",
+								Validation: &JsonValidation{Required: true},
+							},
+							{
+								Path:       "zip",
+								Type:       "string",
+								Validation: &JsonValidation{Required: true},
+							},
+						},
+						Validation: &JsonValidation{Required: true},
+					},
+				},
+			},
+			expectedValid: false,
+			expectedErrors: []string{
+				"address.Required property 'city' not found",
+			},
+		},
+		{
 			name:          "Nil inputs",
 			data:          nil,
 			config:        nil,


### PR DESCRIPTION
## Summary
- extend `TestValidateNestedJson` with invalid JSON string case
- add recursive validation failure case for missing nested object fields

## Testing
- `go test ./...` *(fails: unable to download modules)*

------
https://chatgpt.com/codex/tasks/task_e_684472569c10832793d536be17f6bf1e