### PR TITLE
Add additional AntDesign detection tests

### DIFF
--- a/pkg/resource/metadata_test.go
+++ b/pkg/resource/metadata_test.go
@@ -1348,6 +1348,54 @@ func TestAutoDetectAntDesignComponent(t *testing.T) {
 			},
 			expected: "JsonEditor",
 		},
+		{
+			name: "Multiselect field",
+			field: Field{
+				Name: "tags",
+				Type: "multiselect",
+			},
+			expected: "Select",
+		},
+		{
+			name: "Checkbox field",
+			field: Field{
+				Name: "agree",
+				Type: "checkbox",
+			},
+			expected: "Checkbox",
+		},
+		{
+			name: "Radio field",
+			field: Field{
+				Name: "gender",
+				Type: "radio",
+			},
+			expected: "Radio",
+		},
+		{
+			name: "Time field",
+			field: Field{
+				Name: "startTime",
+				Type: "time",
+			},
+			expected: "TimePicker",
+		},
+		{
+			name: "Datetime field",
+			field: Field{
+				Name: "createdAt",
+				Type: "datetime",
+			},
+			expected: "DatePicker",
+		},
+		{
+			name: "Unknown field type",
+			field: Field{
+				Name: "mystery",
+				Type: "unknown",
+			},
+			expected: "Input",
+		},
 	}
 
 	// Run test cases


### PR DESCRIPTION
## Summary
- cover more form component types in TestAutoDetectAntDesignComponent

## Testing
- `GOPROXY=direct make test`
- `make lint` *(fails: Forbidden errors while fetching modules)*

------
https://chatgpt.com/codex/tasks/task_e_6844772c3ea483278f31813fed320714