### PR TITLE
Add GetField not found test

### DIFF
--- a/pkg/resource/resource_test.go
+++ b/pkg/resource/resource_test.go
@@ -129,6 +129,17 @@ func TestFieldConfiguration(t *testing.T) {
 	assert.Equal(t, "left", idField.List.Fixed)
 }
 
+func TestGetFieldNonExistent(t *testing.T) {
+	res := &DefaultResource{
+		Name:   "users",
+		Model:  TestUser{},
+		Fields: []Field{{Name: "ID"}, {Name: "Name"}},
+	}
+
+	field := res.GetField("NonExistent")
+	assert.Nil(t, field)
+}
+
 func TestSearchableFields(t *testing.T) {
 	// Create resource with specific searchable fields
 	config := ResourceConfig{


### PR DESCRIPTION
## Summary
- add a test for retrieving a missing field from a DefaultResource

## Testing
- `make test` *(fails: forbidden to fetch Go modules)*

------
https://chatgpt.com/codex/tasks/task_e_6844a4a013c48327a9a6a0e54385e26e