### PR TITLE
Add nested pagination tests

### DIFF
--- a/pkg/query/query_test.go
+++ b/pkg/query/query_test.go
@@ -318,6 +318,20 @@ func TestExtractPaginate(t *testing.T) {
 	assert.NotNil(t, paginateOption)
 	assert.Equal(t, 1, paginateOption.Page)
 	assert.Equal(t, 10, paginateOption.PerPage)
+
+	// Test with Refine.js nested pagination object
+	c, _ = createTestContext("pagination[current]=3&pagination[pageSize]=25")
+	paginateOption = ExtractPaginate(c)
+	assert.NotNil(t, paginateOption)
+	assert.Equal(t, 3, paginateOption.Page)
+	assert.Equal(t, 25, paginateOption.PerPage)
+
+	// Test per_page exceeding MaxPageSize is capped
+	c, _ = createTestContext("pagination[pageSize]=200")
+	paginateOption = ExtractPaginate(c)
+	assert.NotNil(t, paginateOption)
+	assert.Equal(t, 1, paginateOption.Page)
+	assert.Equal(t, MaxPageSize, paginateOption.PerPage)
 }
 
 func TestExtractFilters(t *testing.T) {


### PR DESCRIPTION
## Summary
- update TestExtractPaginate with nested `pagination[current]` and cap to MaxPageSize

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6844a488caf4832792ca23e1578fced3