### PR TITLE
Add HS256 enforcement and unexpected method test

### DIFF
--- a/pkg/auth/jwt.go
+++ b/pkg/auth/jwt.go
@@ -63,8 +63,8 @@ func JWTMiddleware(config JWTConfig) gin.HandlerFunc {
 
 		// Parse token
 		token, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
-			// Validate signing method
-			if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
+			// Validate signing method - allow only HS256
+			if token.Method.Alg() != jwt.SigningMethodHS256.Alg() {
 				return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
 			}
 
@@ -142,8 +142,8 @@ func GenerateJWTWithStandardClaims(config JWTConfig, subject string, customClaim
 // ExtractSubjectFromToken extracts the subject from a JWT token
 func ExtractSubjectFromToken(tokenString string, secret string) (string, error) {
 	token, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
-		// Validate signing method
-		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
+		// Validate signing method - allow only HS256
+		if token.Method.Alg() != jwt.SigningMethodHS256.Alg() {
 			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
 		}
 
@@ -176,8 +176,8 @@ func ExtractSubjectFromToken(tokenString string, secret string) (string, error) 
 // ExtractClaimsFromToken extracts all claims from a JWT token
 func ExtractClaimsFromToken(tokenString string, secret string) (jwt.MapClaims, error) {
 	token, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
-		// Validate signing method
-		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
+		// Validate signing method - allow only HS256
+		if token.Method.Alg() != jwt.SigningMethodHS256.Alg() {
 			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
 		}
 

--- a/pkg/auth/jwt_test.go
+++ b/pkg/auth/jwt_test.go
@@ -197,4 +197,18 @@ func TestExtractClaimsFromToken(t *testing.T) {
 	claims, err = ExtractClaimsFromToken("invalid-token", secret)
 	assert.Error(t, err)
 	assert.Nil(t, claims)
+
+	// Test with token signed using a different algorithm
+	token = jwt.NewWithClaims(jwt.SigningMethodHS512, jwt.MapClaims{
+		"sub":  "1",
+		"name": "John Doe",
+		"exp":  time.Now().Add(time.Hour).Unix(),
+	})
+
+	tokenString, _ = token.SignedString([]byte(secret))
+
+	claims, err = ExtractClaimsFromToken(tokenString, secret)
+	assert.Error(t, err)
+	assert.Nil(t, claims)
+	assert.Contains(t, err.Error(), "unexpected signing method")
 }


### PR DESCRIPTION
## Summary
- enforce HS256 signing in JWT helpers
- test that ExtractClaimsFromToken rejects HS512 tokens

## Testing
- `go test ./...` *(fails: Forbidden to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6844a4713cac8327838ff3acfe6ada84