### PR TITLE
Add detach relation tests

### DIFF
--- a/pkg/handler/custom_relation_test.go
+++ b/pkg/handler/custom_relation_test.go
@@ -166,3 +166,39 @@ func TestGetRelatedObjectBelongsTo(t *testing.T) {
 		assert.Error(t, err)
 	})
 }
+
+func TestGetRelatedObjectHasOne(t *testing.T) {
+	rel := resource.Relation{Name: "profile", Field: "Profile", Type: resource.RelationTypeOneToOne}
+
+	t.Run("Struct", func(t *testing.T) {
+		parent := &RelationParent{Profile: &RelationChild{ID: 3}}
+		result, err := getRelatedObject(parent, &rel, nil)
+		assert.NoError(t, err)
+		assert.Equal(t, parent.Profile, result)
+	})
+
+	t.Run("Map", func(t *testing.T) {
+		m := map[string]interface{}{"Profile": &RelationChild{ID: 4}}
+		result, err := getRelatedObject(m, &rel, nil)
+		assert.NoError(t, err)
+		assert.Equal(t, m["Profile"], result)
+	})
+
+	t.Run("FieldMissingStruct", func(t *testing.T) {
+		parent := &RelationParent{}
+		_, err := getRelatedObject(parent, &rel, nil)
+		assert.Error(t, err)
+	})
+
+	t.Run("FieldMissingMap", func(t *testing.T) {
+		m := map[string]interface{}{}
+		_, err := getRelatedObject(m, &rel, nil)
+		assert.Error(t, err)
+	})
+
+	t.Run("UnsupportedType", func(t *testing.T) {
+		badRel := resource.Relation{Name: "tags", Field: "Tags", Type: resource.RelationTypeManyToMany}
+		_, err := getRelatedObject(&RelationParent{}, &badRel, nil)
+		assert.Error(t, err)
+	})
+}


### PR DESCRIPTION
## Summary
- expand `TestUser` with `Tags` field for many-to-many cases
- run `DetachAction` handler tests on HasMany, HasOne and ManyToMany
- validate `getRelatedObject` for struct/map inputs and error paths

## Testing
- `go test ./...` *(fails: forbidden fetching modules)*

------
https://chatgpt.com/codex/tasks/task_e_6844ac6501108327b64d954dbbd1201a