### PR TITLE
Add tests for Swagger handler and batch endpoints

### DIFF
--- a/pkg/swagger/owner_resource_test.go
+++ b/pkg/swagger/owner_resource_test.go
@@ -384,3 +384,39 @@ func TestUpdateBatchEndpoints(t *testing.T) {
 	}
 	assert.Contains(t, postOp2.Description, "The owner ID for all created resources will be set to the authenticated user's ID")
 }
+
+func TestUpdateBatchEndpointsMinimalOpenAPI(t *testing.T) {
+	openAPI := &OpenAPI{
+		Paths: map[string]PathItem{
+			"/books/batch": {
+				"post":   Operation{Responses: map[string]Response{"200": {}}},
+				"put":    Operation{Responses: map[string]Response{"200": {}}},
+				"delete": Operation{Responses: map[string]Response{"200": {}}},
+			},
+		},
+	}
+
+	updateBatchEndpoints(openAPI, "books")
+
+	pi := openAPI.Paths["/books/batch"]
+
+	postOp := pi["post"]
+	assert.NotEmpty(t, postOp.Security)
+	if assert.GreaterOrEqual(t, len(postOp.Security), 1) {
+		assert.Contains(t, postOp.Security[0], "bearerAuth")
+	}
+
+	putOp := pi["put"]
+	assert.NotEmpty(t, putOp.Security)
+	if assert.GreaterOrEqual(t, len(putOp.Security), 1) {
+		assert.Contains(t, putOp.Security[0], "bearerAuth")
+	}
+	assert.Contains(t, putOp.Responses, "403")
+
+	delOp := pi["delete"]
+	assert.NotEmpty(t, delOp.Security)
+	if assert.GreaterOrEqual(t, len(delOp.Security), 1) {
+		assert.Contains(t, delOp.Security[0], "bearerAuth")
+	}
+	assert.Contains(t, delOp.Responses, "403")
+}

--- a/pkg/swagger/swagger_test.go
+++ b/pkg/swagger/swagger_test.go
@@ -1,6 +1,7 @@
 package swagger
 
 import (
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -328,4 +329,22 @@ func TestSwaggerHandler(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, "text/html", w.Header().Get("Content-Type"))
 	assert.Contains(t, w.Body.String(), swaggerHTML)
+}
+
+func TestSwaggerHandlerServer(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.GET("/swagger", SwaggerHandler())
+
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/swagger")
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "text/html", resp.Header.Get("Content-Type"))
+	assert.Contains(t, string(body), swaggerHTML)
 }


### PR DESCRIPTION
## Summary
- add integration test for SwaggerHandler using httptest server
- cover updateBatchEndpoints with a minimal OpenAPI object

## Testing
- `go test ./...` *(fails: github.com/gabriel-vasile/mimetype download forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6844ac7f41dc83278a22e74be2ab2ec1