### PR TITLE
Add validator tests

### DIFF
--- a/pkg/resource/field_test.go
+++ b/pkg/resource/field_test.go
@@ -301,3 +301,15 @@ func TestAsyncValidatorValidate(t *testing.T) {
 	err := validator.Validate("sample")
 	assert.NoError(t, err)
 }
+
+func TestCustomValidatorReturnsNil(t *testing.T) {
+	v := CustomValidator{Expression: "dummy", Message: ""}
+	err := v.Validate(struct{}{})
+	assert.NoError(t, err)
+}
+
+func TestAsyncValidatorReturnsNil(t *testing.T) {
+	v := AsyncValidator{URL: "http://localhost", Message: ""}
+	err := v.Validate(struct{}{})
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
## Summary
- add unit tests for custom and async validators

## Testing
- `go test ./...` *(fails: github.com/gabriel-vasile/mimetype@v1.4.2 download forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6844ac7d4a408327826f259004d6c334