### PR TITLE
Add query option and permission tests

### DIFF
--- a/pkg/resource/options_test.go
+++ b/pkg/resource/options_test.go
@@ -214,3 +214,9 @@ func TestGetQueryOption(t *testing.T) {
 	assert.Equal(t, 10, opts.GetQueryOption("limit"))
 	assert.Nil(t, opts.GetQueryOption("missing"))
 }
+
+func TestGetQueryOptionReturnsNilForMissingKey(t *testing.T) {
+	opts := Options{QueryOptions: map[string]interface{}{"page": 1}}
+
+	assert.Nil(t, opts.GetQueryOption("limit"))
+}

--- a/pkg/resource/resource_test.go
+++ b/pkg/resource/resource_test.go
@@ -665,3 +665,29 @@ func TestGenerateFieldsFromModelWithTags(t *testing.T) {
 		assert.NotEmpty(t, detailsField.Json.Properties)
 	}
 }
+
+func TestDefaultResourceHasPermissionCases(t *testing.T) {
+	t.Run("nil permissions", func(t *testing.T) {
+		r := &DefaultResource{}
+		assert.True(t, r.HasPermission(string(OperationCreate), "any"))
+		assert.True(t, r.HasPermission(string(OperationDelete), "other"))
+	})
+
+	perms := map[string][]string{
+		string(OperationCreate): {"admin", "editor"},
+	}
+
+	r := &DefaultResource{Permissions: perms}
+
+	t.Run("unknown operation", func(t *testing.T) {
+		assert.True(t, r.HasPermission(string(OperationDelete), "guest"))
+	})
+
+	t.Run("role present", func(t *testing.T) {
+		assert.True(t, r.HasPermission(string(OperationCreate), "admin"))
+	})
+
+	t.Run("role absent", func(t *testing.T) {
+		assert.False(t, r.HasPermission(string(OperationCreate), "guest"))
+	})
+}


### PR DESCRIPTION
## Summary
- expand tests for Options `GetQueryOption`
- add additional permission tests for `DefaultResource`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6844ac7c4d84832788ddaf7a8a1fbc21