### PR TITLE
Add tests for new Ant Design type inference

### DIFF
--- a/pkg/resource/metadata.go
+++ b/pkg/resource/metadata.go
@@ -737,6 +737,24 @@ func generateDefaultAntDesignConfig(field *Field) *AntDesignConfigMetadata {
 
 	// Add field-specific props
 	switch field.Type {
+	case "[]string":
+		config.ComponentType = "Select"
+		config.Props["mode"] = "multiple"
+		if len(field.Options) > 0 {
+			options := make([]map[string]interface{}, 0, len(field.Options))
+			for _, opt := range field.Options {
+				options = append(options, map[string]interface{}{
+					"value": opt.Value,
+					"label": opt.Label,
+				})
+			}
+			config.Props["options"] = options
+		}
+	case "bool":
+		config.ComponentType = "Checkbox"
+		config.FormItemProps["valuePropName"] = "checked"
+	case "time.Time":
+		config.ComponentType = "DatePicker"
 	case "string":
 		if field.Form != nil && field.Form.Placeholder != "" {
 			config.Props["placeholder"] = field.Form.Placeholder

--- a/pkg/resource/metadata_test.go
+++ b/pkg/resource/metadata_test.go
@@ -1065,7 +1065,7 @@ func TestGenerateFieldsMetadataWithSpecialFields(t *testing.T) {
 	metadata := GenerateFieldsMetadata(fields)
 
 	// Verify metadata
-	assert.Len(t, metadata, 4)
+	assert.Len(t, metadata, 8)
 
 	// Check avatar field (file type)
 	avatarMeta := findFieldMetadata(metadata, "avatar")
@@ -1435,6 +1435,30 @@ func TestAutoDetectAntDesignComponent(t *testing.T) {
 			expected: "DatePicker",
 		},
 		{
+			name: "String slice field",
+			field: Field{
+				Name: "tagsList",
+				Type: "[]string",
+			},
+			expected: "Select",
+		},
+		{
+			name: "Bool field",
+			field: Field{
+				Name: "agreeTerms",
+				Type: "bool",
+			},
+			expected: "Checkbox",
+		},
+		{
+			name: "Time struct field",
+			field: Field{
+				Name: "eventDate",
+				Type: "time.Time",
+			},
+			expected: "DatePicker",
+		},
+		{
 			name: "Unknown field type",
 			field: Field{
 				Name: "mystery",
@@ -1502,13 +1526,36 @@ func TestGenerateFieldsMetadataWithAntDesign(t *testing.T) {
 			},
 			// No explicit Ant Design config - should be auto-generated
 		},
+		{
+			Name: "tagsList",
+			Type: "[]string",
+			Options: []Option{
+				{Value: "a", Label: "A"},
+				{Value: "b", Label: "B"},
+			},
+			// Should infer Select with multiple mode
+		},
+		{
+			Name: "agreeTerms",
+			Type: "bool",
+			// Should infer Checkbox component
+		},
+		{
+			Name: "eventDate",
+			Type: "time.Time",
+			// Should infer DatePicker component
+		},
+		{
+			Name: "custom",
+			Type: "unknownType",
+		},
 	}
 
 	// Generate metadata
 	metadata := GenerateFieldsMetadata(fields)
 
 	// Verify metadata
-	assert.Len(t, metadata, 4)
+	assert.Len(t, metadata, 8)
 
 	// Check name field with explicit config
 	nameMeta := findFieldMetadata(metadata, "name")
@@ -1557,4 +1604,26 @@ func TestGenerateFieldsMetadataWithAntDesign(t *testing.T) {
 	assert.Equal(t, "Administrator", options[0]["label"])
 	assert.Equal(t, "user", options[1]["value"])
 	assert.Equal(t, "Regular User", options[1]["label"])
+
+	// Check tagsList field
+	tagsMeta := findFieldMetadata(metadata, "tagsList")
+	assert.NotNil(t, tagsMeta)
+	assert.Equal(t, "Select", tagsMeta.AntDesign.ComponentType)
+	assert.Equal(t, "multiple", tagsMeta.AntDesign.Props["mode"])
+
+	// Check agreeTerms field
+	agreeMeta := findFieldMetadata(metadata, "agreeTerms")
+	assert.NotNil(t, agreeMeta)
+	assert.Equal(t, "Checkbox", agreeMeta.AntDesign.ComponentType)
+	assert.Equal(t, "checked", agreeMeta.AntDesign.FormItemProps["valuePropName"])
+
+	// Check eventDate field
+	eventMeta := findFieldMetadata(metadata, "eventDate")
+	assert.NotNil(t, eventMeta)
+	assert.Equal(t, "DatePicker", eventMeta.AntDesign.ComponentType)
+
+	// Check custom field fallback
+	customMeta := findFieldMetadata(metadata, "custom")
+	assert.NotNil(t, customMeta)
+	assert.Equal(t, "Input", customMeta.AntDesign.ComponentType)
 }

--- a/pkg/resource/utils.go
+++ b/pkg/resource/utils.go
@@ -567,6 +567,12 @@ func AutoDetectAntDesignComponent(field *Field) string {
 
 	// Map field type to Ant Design component
 	switch field.Type {
+	case "[]string":
+		return "Select"
+	case "bool":
+		return "Checkbox"
+	case "time.Time":
+		return "DatePicker"
 	case "string":
 		// Check if it's an enum/select type
 		if len(field.Options) > 0 || field.Select != nil {


### PR DESCRIPTION
## Summary
- support Go types `[]string`, `bool` and `time.Time` when inferring Ant Design components
- default unsupported types to `Input`
- expand tests to cover these scenarios

## Testing
- `make lint` *(fails: Get https://storage.googleapis.com/... Forbidden)*
- `make test` *(fails: Get https://storage.googleapis.com/... Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6844b59f29a08327bcc8b397a8170353